### PR TITLE
fix(breadcrumb-item): remove role `link`

### DIFF
--- a/src/runtime/components/BreadcrumbItem.vue
+++ b/src/runtime/components/BreadcrumbItem.vue
@@ -50,7 +50,6 @@ const spanAttrs = computed(() => {
       props.last ? ui.value.last : [],
     ],
     'label': props.label,
-    'role': 'link',
     'aria-disabled': true,
     'aria-current': props.current ? (props.ariaCurrent || 'page') : undefined,
   }


### PR DESCRIPTION
### Description

That role is implicit on the `a` element that's now used.

### Linked Issues

https://github.com/harlan-zw/nuxt-seo-ui/issues/3

### Additional context

n/a
